### PR TITLE
Bump zookeeper from 3.3.6 to 3.4.14 in /dubbo_service_consumer

### DIFF
--- a/dubbo_service_consumer/pom.xml
+++ b/dubbo_service_consumer/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.3.6</version>
+      <version>3.4.14</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Bumps zookeeper from 3.3.6 to 3.4.14.

Signed-off-by: dependabot[bot] <support@github.com>